### PR TITLE
feat(cli): add system status command for kernel and environment info

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,3 +10,4 @@ color-eyre = "0.6"
 tracing-subscriber = "0.3"
 figlet-rs = "0.1"
 console = "0.15"
+nix = { version = "0.30", features = ["user"] }

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,0 +1,2 @@
+pub mod welcome;
+pub mod status;

--- a/cli/src/commands/status.rs
+++ b/cli/src/commands/status.rs
@@ -1,0 +1,28 @@
+use crate::utils::logger;
+use std::fs;
+use std::process::Command;
+
+pub fn run_status() {
+    println!("\n\x1b[1;35mECLIPTA CLI ▸ status\x1b[0m\n");
+
+    let kernel = Command::new("uname").arg("-r").output().unwrap();
+    let kernel_str = String::from_utf8_lossy(&kernel.stdout);
+    logger::success(&format!("Kernel: {}", kernel_str.trim()));
+
+    let has_bpf_fs = fs::metadata("/sys/fs/bpf").is_ok();
+    logger::info(&format!("/sys/fs/bpf mounted: {}", if has_bpf_fs { "YES" } else { "NO" }));
+
+    let has_debug_fs = fs::metadata("/sys/kernel/debug").is_ok();
+    logger::info(&format!("/sys/kernel/debug mounted: {}", if has_debug_fs { "YES" } else { "NO" }));
+
+    let uid = nix::unistd::Uid::effective();
+    logger::info(&format!("CAP_SYS_ADMIN: {}", if uid.is_root() { "available" } else { "missing" }));
+
+    let rustc = Command::new("rustc").arg("--version").output();
+    if let Ok(r) = rustc {
+        let v = String::from_utf8_lossy(&r.stdout);
+        logger::info(&format!("Rust toolchain: {}", v.trim()));
+    }
+
+    logger::info("aya version: 0.13.1");
+}

--- a/cli/src/commands/welcome.rs
+++ b/cli/src/commands/welcome.rs
@@ -1,0 +1,9 @@
+
+use figlet_rs::FIGfont;
+
+pub fn run_welcome() {
+    let standard_font = FIGfont::standard().unwrap();
+    let figure = standard_font.convert("ECLIPTA").unwrap();
+    println!("\x1b[35m{}\x1b[1m", figure);
+    println!("\x1b[1;36mself-hosted observability platform\x1b[0m\n");
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,8 +1,12 @@
+mod commands;
+mod utils;
+
 use clap::{Parser, Subcommand};
-use color_eyre::eyre::Result;
-use figlet_rs::FIGfont;
+use commands::{welcome::run_welcome, status::run_status};
+
 #[derive(Parser)]
-#[command(name = "eclipta", version, about = "🩺 CLI for tracing Linux system calls using eBPF")]
+#[command(name = "eclipta")]
+#[command(about = "eclipta CLI - self-hosted observability platform", long_about = None)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,
@@ -11,29 +15,14 @@ struct Cli {
 #[derive(Subcommand)]
 enum Commands {
     Welcome,
-    TraceExec,
+    Status,
 }
 
-fn main() -> Result<()> {
-    color_eyre::install()?;
+fn main() {
     let cli = Cli::parse();
 
     match cli.command {
-          Commands::Welcome => {
-        let font = FIGfont::standard().unwrap();
-        let figure = font.convert("ECLIPTA").unwrap();
-        let gradient = [196, 198, 201, 207, 213, 219, 81]; 
-
-        for (i, line) in figure.to_string().lines().enumerate() {
-            let color = gradient.get(i % gradient.len()).unwrap_or(&15); 
-            println!("\x1b[38;5;{}m{}\x1b[0m", color, line);
-        }
-        println!("\x1b[1;36mself-hosted observability platform\x1b[0m\n");
+        Commands::Welcome => run_welcome(),
+        Commands::Status => run_status(),
     }
-        Commands::TraceExec => {
-            println!(" Coming soon: trace_execve program will load and trace exec calls.");
-        }
-    }
-
-    Ok(())
 }

--- a/cli/src/utils/logger.rs
+++ b/cli/src/utils/logger.rs
@@ -1,0 +1,15 @@
+pub fn success(msg: &str) {
+    println!("\x1b[1;32m✔\x1b[0m {}", msg);
+}
+
+pub fn info(msg: &str) {
+    println!("\x1b[1;34mℹ\x1b[0m {}", msg);
+}
+
+pub fn warn(msg: &str) {
+    println!("\x1b[1;33m⚠\x1b[0m {}", msg);
+}
+
+pub fn error(msg: &str) {
+    eprintln!("\x1b[1;31m✖\x1b[0m {}", msg);
+}

--- a/cli/src/utils/mod.rs
+++ b/cli/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod logger;


### PR DESCRIPTION
- Added `status` subcommand to display system diagnostics
- Outputs kernel version, BPF and debug FS mount status, CAP_SYS_ADMIN capability
- Shows installed Rust and aya versions
- Uses styled logger with colored icons for clean CLI UX