### PR TITLE
feat(cli): add `logs` command for real-time eBPF event reading

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,3 +11,8 @@ tracing-subscriber = "0.3"
 figlet-rs = "0.1"
 console = "0.15"
 nix = { version = "0.30", features = ["user"] }
+anyhow = "1"
+log = "0.4"
+tokio = { version = "1.38", features = ["rt-multi-thread", "time", "signal"] }
+byteorder = "1"
+bytes = "1.10.1"

--- a/cli/src/commands/load.rs
+++ b/cli/src/commands/load.rs
@@ -1,4 +1,4 @@
-use aya::{BpfLoader, programs::TracePoint};
+use aya::{programs::TracePoint, EbpfLoader};
 use clap::Args;
 use std::path::PathBuf;
 use crate::utils::logger::{info, success, error};
@@ -44,7 +44,7 @@ pub fn handle_load(opts: LoadOptions) {
         info(&format!("Target tracepoint: {}", opts.tracepoint));
     }
 
-    match BpfLoader::new().load_file(&opts.program) {
+    match EbpfLoader::new().load_file(&opts.program) {
         Ok(mut bpf) => {
             match bpf.program_mut(&opts.name) {
                 Some(prog) => {

--- a/cli/src/commands/logs.rs
+++ b/cli/src/commands/logs.rs
@@ -1,0 +1,86 @@
+use crate::utils::logger::{info, error};
+use aya::{Ebpf, maps::perf::PerfEventArray, util::online_cpus};
+use bytes::BytesMut;
+use clap::Args;
+use std::{convert::TryInto, path::PathBuf, time::Duration};
+use tokio::{signal, task, time};
+
+#[derive(Args, Debug)]
+pub struct LogOptions {
+    #[arg(short, long, default_value = "target/trace_execve.o")]
+    pub program: PathBuf,
+
+    #[arg(short, long, default_value = "trace_execve_events")]
+    pub map: String,
+}
+
+pub async fn handle_logs(opts: LogOptions) {
+    if !opts.program.exists() {
+        error("Missing compiled eBPF program. Run `eclipta load` first.");
+        return;
+    }
+
+    let mut bpf = match Ebpf::load_file(&opts.program) {
+        Ok(bpf) => bpf,
+        Err(e) => {
+            error(&format!("Failed to load ELF: {}", e));
+            return;
+        }
+    };
+
+    let map = match bpf.take_map(&opts.map) {
+        Some(m) => m,
+        None => {
+            error(&format!("Map '{}' not found in program", opts.map));
+            return;
+        }
+    };
+
+    let mut perf_array: PerfEventArray<_> = match map.try_into() {
+        Ok(pa) => pa,
+        Err(_) => {
+            error("Map is not a valid PerfEventArray");
+            return;
+        }
+    };
+
+    info("Listening for perf event logs...\nPress Ctrl+C to exit.\n");
+
+    for cpu_id in online_cpus().unwrap() {
+        let mut buf = match perf_array.open(cpu_id, None) {
+            Ok(b) => b,
+            Err(e) => {
+                error(&format!("Failed to open perf buffer on CPU {}: {}", cpu_id, e));
+                continue;
+            }
+        };
+
+        task::spawn(async move {
+            let mut buffers = vec![BytesMut::with_capacity(1024)];
+            loop {
+                match buf.read_events(&mut buffers) {
+                    Ok(events) => {
+                        for buf in &buffers[..events.read] {
+                            let event = String::from_utf8_lossy(&buf);
+                            println!("🟢 {}", event);
+                        }
+                        if events.lost > 0 {
+                            error(&format!("Lost {} events due to buffer overflow", events.lost));
+                        }
+                    }
+                    Err(e) => {
+                        error(&format!("Failed to read events: {}", e));
+                    }
+                }
+                time::sleep(Duration::from_millis(100)).await;
+            }
+        });
+    }
+
+    // Wait for Ctrl+C
+    if let Err(e) = signal::ctrl_c().await {
+        error(&format!("Failed to wait for Ctrl+C: {}", e));
+    }
+
+    println!("\n🛑 Exiting logs...");
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
 pub mod welcome;
 pub mod status;
 pub mod load;
+pub mod logs;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2,11 +2,12 @@ mod commands;
 mod utils;
 
 use clap::{Parser, Subcommand};
-use commands::{welcome::run_welcome, status::run_status, load::{handle_load, LoadOptions}};
+use commands::{load::handle_load, logs::LogOptions, status::run_status, welcome::run_welcome};
+use commands::logs::handle_logs;
 
 #[derive(Parser)]
 #[command(name = "eclipta")]
-#[command(about = "eclipta CLI - self-hosted observability platform", long_about = None)]
+#[command(about = "eclipta CLI - self-hosted observability platform")]
 struct Cli {
     #[command(subcommand)]
     command: Commands,
@@ -16,7 +17,8 @@ struct Cli {
 enum Commands {
     Welcome,
     Status,
-    Load(LoadOptions),
+    Load(commands::load::LoadOptions),
+    Logs(LogOptions),
 }
 
 fn main() {
@@ -26,5 +28,9 @@ fn main() {
         Commands::Welcome => run_welcome(),
         Commands::Status => run_status(),
         Commands::Load(opts) => handle_load(opts),
+        Commands::Logs(opts) => {
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            rt.block_on(handle_logs(opts));
+        }
     }
 }


### PR DESCRIPTION
- Added `logs` command to the eclipta CLI
- Supports loading eBPF maps (PerfEventArray) and reading events per CPU
- Uses async tokio tasks to concurrently read buffers from all online CPUs
- Gracefully handles Ctrl+C
- Prepares ground for future JSON, filter, or file-output support