### PR TITLE
feat: add inspect command to view programs and maps in ELF

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,3 +16,5 @@ log = "0.4"
 tokio = { version = "1.38", features = ["rt-multi-thread", "time", "signal"] }
 byteorder = "1"
 bytes = "1.10.1"
+serde_json = "1.0"
+serde = { version = "1.0", features = ["derive"] }

--- a/cli/src/commands/inspect.rs
+++ b/cli/src/commands/inspect.rs
@@ -1,0 +1,56 @@
+use aya::{Ebpf};
+use clap::Args;
+use std::path::PathBuf;
+use crate::utils::logger::{info, error};
+use serde_json;
+
+
+#[derive(Args, Debug)]
+pub struct InspectOptions {
+    #[arg(short, long, default_value = "target/trace_execve.o")]
+    pub program: PathBuf,
+
+    #[arg(long)]
+    pub json: bool,
+
+    #[arg(long)]
+    pub verbose: bool,
+}
+
+pub fn handle_inspect(opts: InspectOptions) {
+    if !opts.program.exists() {
+        error("Missing compiled eBPF program.");
+        return;
+    }
+
+    let bpf = match Ebpf::load_file(&opts.program) {
+        Ok(b) => b,
+        Err(e) => {
+            error(&format!("Failed to parse ELF: {}", e));
+            return;
+        }
+    };
+
+    let programs: Vec<_> = bpf.programs().map(|(name, _)| name.to_string()).collect();
+    let maps: Vec<_> = bpf.maps().map(|(name, _)| name.to_string()).collect();
+
+    if opts.json {
+        let output = serde_json::json!({
+            "elf": opts.program.display().to_string(),
+            "programs": programs,
+            "maps": maps,
+        });
+        println!("{}", serde_json::to_string_pretty(&output).unwrap());
+    } else {
+        info(&format!("✅ ELF: {}", opts.program.display()));
+        println!("Programs:");
+        for name in &programs {
+            println!("  - {}", name);
+        }
+
+        println!("Maps:");
+        for name in &maps {
+            println!("  - {}", name);
+        }
+    }
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -3,3 +3,4 @@ pub mod status;
 pub mod load;
 pub mod logs;
 pub mod unload;
+pub mod inspect;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,6 +4,8 @@ mod utils;
 use clap::{Parser, Subcommand};
 use commands::{welcome::run_welcome, status::run_status, load::handle_load, logs::handle_logs, unload::{handle_unload, UnloadOptions}};
 use crate::commands::logs::LogOptions;
+use commands::inspect::{handle_inspect, InspectOptions};
+
 
 
 #[derive(Parser)]
@@ -21,6 +23,8 @@ enum Commands {
     Load(commands::load::LoadOptions),
     Logs(LogOptions),
     Unload(UnloadOptions),
+    Inspect(InspectOptions),
+
 }
 
 fn main() {
@@ -30,7 +34,8 @@ fn main() {
         Commands::Welcome => run_welcome(),
         Commands::Status => run_status(),
         Commands::Load(opts) => handle_load(opts),
-         Commands::Unload(opts) => handle_unload(opts),
+        Commands::Unload(opts) => handle_unload(opts),
+        Commands::Inspect(opts) => handle_inspect(opts),
         Commands::Logs(opts) => {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(handle_logs(opts));

--- a/cli/src/utils/logger.rs
+++ b/cli/src/utils/logger.rs
@@ -6,9 +6,9 @@ pub fn info(msg: &str) {
     println!("\x1b[1;34mℹ\x1b[0m {}", msg);
 }
 
-pub fn warn(msg: &str) {
-    println!("\x1b[1;33m⚠\x1b[0m {}", msg);
-}
+// pub fn warn(msg: &str) {
+//     println!("\x1b[1;33m⚠\x1b[0m {}", msg);
+// }
 
 pub fn error(msg: &str) {
     eprintln!("\x1b[1;31m✖\x1b[0m {}", msg);


### PR DESCRIPTION
- Introduced `inspect` subcommand to analyze compiled eBPF ELF files.
- Lists all programs and maps with their names and types.
- Supports both human-readable and `--json` output formats.
- Uses `Ebpf::load_file` to parse and introspect ELF files.
- Useful for debugging and understanding what an .o file contains before loading.

Example:
  sudo ./eclipta inspect -p target/trace_execve.o --json