### PR TITLE
feat(cli): add `agents` command to list active eclipta agents

### DIFF
--- a/cli/src/commands/agents.rs
+++ b/cli/src/commands/agents.rs
@@ -1,0 +1,76 @@
+use clap::Args;
+use std::{fs, path::PathBuf};
+use serde::{Deserialize, Serialize};
+use crate::utils::logger::{info, success, error};
+
+#[derive(Args, Debug)]
+pub struct AgentOptions {
+    #[arg(long)]
+    pub json: bool,
+
+    #[arg(long)]
+    pub verbose: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct AgentStatus {
+    id: String,
+    hostname: String,
+    kernel: String,
+    version: String,
+    last_seen: String,
+    uptime_secs: u64,
+}
+
+pub fn handle_agents(opts: AgentOptions) {
+    let dir = PathBuf::from("/run/eclipta");
+
+    let files = match fs::read_dir(&dir) {
+        Ok(f) => f,
+        Err(e) => {
+            error(&format!("❌ Failed to read /run/eclipta: {}", e));
+            return;
+        }
+    };
+
+    let mut agents = Vec::new();
+
+    for entry in files.flatten() {
+        if let Ok(content) = fs::read_to_string(entry.path()) {
+            if let Ok(agent) = serde_json::from_str::<AgentStatus>(&content) {
+                agents.push(agent);
+            }
+        }
+    }
+
+    if agents.is_empty() {
+        info("No agents found.");
+        return;
+    }
+
+    if opts.json {
+        let out = serde_json::to_string_pretty(&agents).unwrap();
+        println!("{}", out);
+        return;
+    }
+
+    success("🟢 Connected Agents:");
+    for agent in &agents {
+        println!(
+            "• [{}] {} - {} (uptime: {}s)",
+            agent.status_string(),
+            agent.id,
+            agent.hostname,
+            agent.uptime_secs
+        );
+        if opts.verbose {
+            println!("   └─ Kernel: {} | Version: {}", agent.kernel, agent.version);
+        }
+    }
+}
+
+impl AgentStatus {
+    fn status_string(&self) -> &'static str {
+        "online"
+    }
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -4,3 +4,4 @@ pub mod load;
 pub mod logs;
 pub mod unload;
 pub mod inspect;
+pub mod agents;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -5,6 +5,8 @@ use clap::{Parser, Subcommand};
 use commands::{welcome::run_welcome, status::run_status, load::handle_load, logs::handle_logs, unload::{handle_unload, UnloadOptions}};
 use crate::commands::logs::LogOptions;
 use commands::inspect::{handle_inspect, InspectOptions};
+use commands::agents::{handle_agents, AgentOptions};
+
 
 
 
@@ -24,6 +26,7 @@ enum Commands {
     Logs(LogOptions),
     Unload(UnloadOptions),
     Inspect(InspectOptions),
+    Agents(AgentOptions),
 
 }
 
@@ -36,6 +39,7 @@ fn main() {
         Commands::Load(opts) => handle_load(opts),
         Commands::Unload(opts) => handle_unload(opts),
         Commands::Inspect(opts) => handle_inspect(opts),
+        Commands::Agents(opts) => handle_agents(opts),
         Commands::Logs(opts) => {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(handle_logs(opts));


### PR DESCRIPTION
- Introduced `eclipta agents` subcommand in the CLI
- Reads agent heartbeat files from /run/eclipta
- Parses JSON agent data into structured output
- Supports human-readable and --json modes
- Displays hostname, kernel, uptime, and version
- Enables dynamic multi-agent observability listing