### PR TITLE
feat(cli): add `inspect-agent` command to view single agent status

### DIFF
--- a/cli/src/commands/agents_inspect.rs
+++ b/cli/src/commands/agents_inspect.rs
@@ -1,0 +1,57 @@
+use clap::Args;
+use std::{fs, path::PathBuf};
+use serde::{Deserialize, Serialize};
+use crate::utils::logger::{error, success, info};
+
+#[derive(Args, Debug)]
+pub struct InspectAgentOptions {
+    /// Agent ID (like agent-001)
+    pub id: String,
+
+    /// Output JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct AgentStatus {
+    id: String,
+    hostname: String,
+    kernel: String,
+    version: String,
+    last_seen: String,
+    uptime_secs: u64,
+}
+
+pub fn handle_inspect_agent(opts: InspectAgentOptions) {
+    let path = PathBuf::from(format!("/run/eclipta/{}.json", opts.id));
+
+    let content = match fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(e) => {
+            error(&format!("Failed to read agent file: {}", e));
+            return;
+        }
+    };
+
+    let agent: AgentStatus = match serde_json::from_str(&content) {
+        Ok(a) => a,
+        Err(e) => {
+            error(&format!("Invalid JSON in agent file: {}", e));
+            return;
+        }
+    };
+
+    if opts.json {
+        let output = serde_json::to_string_pretty(&agent).unwrap();
+        println!("{}", output);
+        return;
+    }
+
+    success(&format!("Agent: {}", agent.id));
+    info(&format!("Hostname: {}", agent.hostname));
+    info(&format!("Kernel: {}", agent.kernel));
+    info(&format!("Uptime: {}s", agent.uptime_secs));
+    info(&format!("Last Seen: {}", agent.last_seen));
+    info(&format!("Version: {}", agent.version));
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -5,3 +5,4 @@ pub mod logs;
 pub mod unload;
 pub mod inspect;
 pub mod agents;
+pub mod agents_inspect;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -6,8 +6,7 @@ use commands::{welcome::run_welcome, status::run_status, load::handle_load, logs
 use crate::commands::logs::LogOptions;
 use commands::inspect::{handle_inspect, InspectOptions};
 use commands::agents::{handle_agents, AgentOptions};
-
-
+use commands::agents_inspect::{handle_inspect_agent, InspectAgentOptions};
 
 
 #[derive(Parser)]
@@ -26,6 +25,7 @@ enum Commands {
     Logs(LogOptions),
     Unload(UnloadOptions),
     Inspect(InspectOptions),
+    InspectAgent(InspectAgentOptions),
     Agents(AgentOptions),
 
 }
@@ -40,6 +40,7 @@ fn main() {
         Commands::Unload(opts) => handle_unload(opts),
         Commands::Inspect(opts) => handle_inspect(opts),
         Commands::Agents(opts) => handle_agents(opts),
+        Commands::InspectAgent(opts) => handle_inspect_agent(opts),
         Commands::Logs(opts) => {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(handle_logs(opts));


### PR DESCRIPTION
- Adds `eclipta inspect-agent <id>` command
- Loads /run/eclipta/<id>.json and shows agent metadata
- Supports both JSON and human-readable output