### PR TITLE
feat(cli): add `restart-agent` command to signal agent restarts

### DIFF
--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -6,3 +6,4 @@ pub mod unload;
 pub mod inspect;
 pub mod agents;
 pub mod agents_inspect;
+pub mod restart_agent;

--- a/cli/src/commands/restart_agent.rs
+++ b/cli/src/commands/restart_agent.rs
@@ -1,0 +1,22 @@
+use clap::Args;
+use std::{fs, path::PathBuf};
+use crate::utils::logger::{error, success};
+
+#[derive(Args, Debug)]
+pub struct RestartAgentOptions {
+    /// Agent ID like agent-001
+    pub id: String,
+}
+
+pub fn handle_restart_agent(opts: RestartAgentOptions) {
+    let trigger_file = PathBuf::from(format!("/run/eclipta/restart-{}.trigger", opts.id));
+
+    match fs::write(&trigger_file, b"restart") {
+        Ok(_) => {
+            success(&format!("Restart signal sent to agent `{}`", opts.id));
+        }
+        Err(e) => {
+            error(&format!("Failed to create trigger file: {}", e));
+        }
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -7,6 +7,8 @@ use crate::commands::logs::LogOptions;
 use commands::inspect::{handle_inspect, InspectOptions};
 use commands::agents::{handle_agents, AgentOptions};
 use commands::agents_inspect::{handle_inspect_agent, InspectAgentOptions};
+use commands::restart_agent::{handle_restart_agent, RestartAgentOptions};
+
 
 
 #[derive(Parser)]
@@ -26,6 +28,7 @@ enum Commands {
     Unload(UnloadOptions),
     Inspect(InspectOptions),
     InspectAgent(InspectAgentOptions),
+    RestartAgent(RestartAgentOptions),
     Agents(AgentOptions),
 
 }
@@ -41,6 +44,7 @@ fn main() {
         Commands::Inspect(opts) => handle_inspect(opts),
         Commands::Agents(opts) => handle_agents(opts),
         Commands::InspectAgent(opts) => handle_inspect_agent(opts),
+        Commands::RestartAgent(opts) => handle_restart_agent(opts),
         Commands::Logs(opts) => {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(handle_logs(opts));


### PR DESCRIPTION
- Adds `eclipta restart-agent <id>` CLI command
- Creates /run/eclipta/restart-<id>.trigger file
- Future agents will watch this file and restart themselves