### PR TITLE
feat(cli): add `agent-logs` command to tail logs from agents

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,7 +13,7 @@ console = "0.15"
 nix = { version = "0.30", features = ["user"] }
 anyhow = "1"
 log = "0.4"
-tokio = { version = "1.38", features = ["rt-multi-thread", "time", "signal"] }
+tokio = { version = "1.38", features = ["rt-multi-thread", "time", "signal", "fs", "io-util"] }
 byteorder = "1"
 bytes = "1.10.1"
 serde_json = "1.0"

--- a/cli/src/commands/agent_logs.rs
+++ b/cli/src/commands/agent_logs.rs
@@ -1,0 +1,66 @@
+use clap::Args;
+use std::path::PathBuf;
+use tokio::fs::File;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use crate::utils::logger::{error, info};
+use tokio::time::{sleep, Duration};
+use std::fs;
+use std::ffi::OsStr;
+
+#[derive(Args, Debug)]
+pub struct AgentLogsOptions {
+    /// Agent ID like agent-001 (optional)
+    #[arg(long)]
+    pub id: Option<String>,
+}
+
+pub async fn handle_agent_logs(opts: AgentLogsOptions) {
+    let log_dir = PathBuf::from("/run/eclipta/logs");
+
+    if !log_dir.exists() {
+        error("Log directory not found: /run/eclipta/logs");
+        return;
+    }
+
+    let files: Vec<PathBuf> = if let Some(id) = &opts.id {
+        let p = log_dir.join(format!("{}.log", id));
+        if !p.exists() {
+            error(&format!("Log file not found: {}", p.display()));
+            return;
+        }
+        vec![p]
+    } else {
+        match fs::read_dir(&log_dir) {
+            Ok(entries) => entries
+                .flatten()
+                .filter(|e| e.path().extension() == Some(OsStr::new("log")))
+                .map(|e| e.path())
+                .collect(),
+            Err(e) => {
+                error(&format!("Failed to read log directory: {}", e));
+                return;
+            }
+        }
+    };
+
+    for file in files {
+        let file_name = file.file_name().unwrap().to_string_lossy().to_string();
+        let f = File::open(&file).await.unwrap();
+        let reader = BufReader::new(f);
+        let mut lines = reader.lines();
+
+        info(&format!("Tailing logs from: {}", file_name));
+
+        tokio::spawn(async move {
+            while let Ok(Some(line)) = lines.next_line().await {
+                println!(" [{}] {}", file_name, line);
+                sleep(Duration::from_millis(200)).await;
+            }
+        });
+    }
+
+    // Keep the program running to tail
+    loop {
+        sleep(Duration::from_secs(1)).await;
+    }
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -7,3 +7,4 @@ pub mod inspect;
 pub mod agents;
 pub mod agents_inspect;
 pub mod restart_agent;
+pub mod agent_logs;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -8,7 +8,7 @@ use commands::inspect::{handle_inspect, InspectOptions};
 use commands::agents::{handle_agents, AgentOptions};
 use commands::agents_inspect::{handle_inspect_agent, InspectAgentOptions};
 use commands::restart_agent::{handle_restart_agent, RestartAgentOptions};
-
+use commands::agent_logs::{handle_agent_logs, AgentLogsOptions};
 
 
 #[derive(Parser)]
@@ -30,7 +30,7 @@ enum Commands {
     InspectAgent(InspectAgentOptions),
     RestartAgent(RestartAgentOptions),
     Agents(AgentOptions),
-
+    AgentLogs(AgentLogsOptions),
 }
 
 fn main() {
@@ -45,6 +45,10 @@ fn main() {
         Commands::Agents(opts) => handle_agents(opts),
         Commands::InspectAgent(opts) => handle_inspect_agent(opts),
         Commands::RestartAgent(opts) => handle_restart_agent(opts),
+        Commands::AgentLogs(opts) => {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(handle_agent_logs(opts));
+},
         Commands::Logs(opts) => {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(handle_logs(opts));


### PR DESCRIPTION
- Adds `eclipta agent-logs` to stream logs from one or all agents
- Reads files from /run/eclipta/logs/agent-*.log
- Uses async tokio I/O for real-time streaming