### PR TITLE
feat(cli): add `live` command for TUI real-time agent metrics

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -18,3 +18,5 @@ byteorder = "1"
 bytes = "1.10.1"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
+tui = "0.19"
+crossterm = "0.27"

--- a/cli/src/commands/live.rs
+++ b/cli/src/commands/live.rs
@@ -1,0 +1,121 @@
+use std::{fs, path::PathBuf, time::Duration};
+use serde::Deserialize;
+use tokio::time::sleep;
+
+use tui::{
+    backend::CrosstermBackend,
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Modifier, Style},
+    text::{Span, Spans},
+    widgets::{Block, Borders, Cell, Row, Table},
+    Terminal,
+};
+
+use crossterm::{
+    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+
+#[derive(Deserialize, Debug)]
+pub struct AgentLiveStatus {
+    pub id: String,
+    pub hostname: String,
+    pub uptime_secs: u64,
+    pub cpu: Option<f32>,
+    pub mem: Option<String>,
+}
+
+pub async fn handle_live() {
+    let mut stdout = std::io::stdout();
+    enable_raw_mode().unwrap();
+    execute!(stdout, EnterAlternateScreen, EnableMouseCapture).unwrap();
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend).unwrap();
+
+    loop {
+        // Check if user pressed 'q' to quit
+        if event::poll(Duration::from_millis(100)).unwrap() {
+            if let Event::Key(key) = event::read().unwrap() {
+                if key.code == KeyCode::Char('q') {
+                    break;
+                }
+            }
+        }
+
+        // Read agent JSON files
+        let dir = PathBuf::from("/run/eclipta");
+        let mut agents = Vec::new();
+
+        if let Ok(files) = fs::read_dir(&dir) {
+            for entry in files.flatten() {
+                if entry.file_name().to_string_lossy().starts_with("agent-") {
+                    if let Ok(contents) = fs::read_to_string(entry.path()) {
+                        if let Ok(agent) = serde_json::from_str::<AgentLiveStatus>(&contents) {
+                            agents.push(agent);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Draw UI
+        terminal.draw(|f| {
+            let chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .margin(1)
+                .constraints([Constraint::Length(3), Constraint::Min(1)].as_ref())
+                .split(f.size());
+
+            let title = Block::default()
+                .title(Span::styled(
+                    "ECLIPTA LIVE – Press 'q' to quit",
+                    Style::default()
+                        .fg(Color::Magenta)
+                        .add_modifier(Modifier::BOLD),
+                ))
+                .borders(Borders::ALL);
+            f.render_widget(title, chunks[0]);
+
+            let header = ["ID", "Hostname", "Uptime", "CPU%", "Memory"];
+            let rows: Vec<Row> = agents
+                .iter()
+                .map(|a| {
+                    Row::new(vec![
+                        Cell::from(a.id.clone()),
+                        Cell::from(a.hostname.clone()),
+                        Cell::from(format!("{}s", a.uptime_secs)),
+                        Cell::from(
+                            a.cpu
+                                .map(|v| format!("{:.1}", v))
+                                .unwrap_or_else(|| "--".to_string()),
+                        ),
+                        Cell::from(a.mem.clone().unwrap_or_else(|| "--".to_string())),
+                    ])
+                })
+                .collect();
+
+            let table = Table::new(rows)
+                .header(
+                    Row::new(header)
+                        .style(Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+                )
+                .block(Block::default().title("Agents").borders(Borders::ALL))
+                .widths(&[
+                    Constraint::Length(12),
+                    Constraint::Length(18),
+                    Constraint::Length(10),
+                    Constraint::Length(10),
+                    Constraint::Length(10),
+                ])
+                .column_spacing(2);
+            f.render_widget(table, chunks[1]);
+        }).unwrap();
+
+        sleep(Duration::from_secs(2)).await;
+    }
+
+    disable_raw_mode().unwrap();
+    execute!(terminal.backend_mut(), LeaveAlternateScreen, DisableMouseCapture).unwrap();
+    terminal.show_cursor().unwrap();
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -8,3 +8,4 @@ pub mod agents;
 pub mod agents_inspect;
 pub mod restart_agent;
 pub mod agent_logs;
+pub mod live;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -9,6 +9,8 @@ use commands::agents::{handle_agents, AgentOptions};
 use commands::agents_inspect::{handle_inspect_agent, InspectAgentOptions};
 use commands::restart_agent::{handle_restart_agent, RestartAgentOptions};
 use commands::agent_logs::{handle_agent_logs, AgentLogsOptions};
+use commands::live::handle_live;
+
 
 
 #[derive(Parser)]
@@ -31,8 +33,8 @@ enum Commands {
     RestartAgent(RestartAgentOptions),
     Agents(AgentOptions),
     AgentLogs(AgentLogsOptions),
+    Live,
 }
-
 fn main() {
     let cli = Cli::parse();
 
@@ -42,16 +44,20 @@ fn main() {
         Commands::Load(opts) => handle_load(opts),
         Commands::Unload(opts) => handle_unload(opts),
         Commands::Inspect(opts) => handle_inspect(opts),
-        Commands::Agents(opts) => handle_agents(opts),
-        Commands::InspectAgent(opts) => handle_inspect_agent(opts),
-        Commands::RestartAgent(opts) => handle_restart_agent(opts),
-        Commands::AgentLogs(opts) => {
-    let rt = tokio::runtime::Runtime::new().unwrap();
-    rt.block_on(handle_agent_logs(opts));
-},
         Commands::Logs(opts) => {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(handle_logs(opts));
-        }
+        },
+        Commands::Agents(opts) => handle_agents(opts),
+        Commands::AgentLogs(opts) => {
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            rt.block_on(handle_agent_logs(opts));
+        },
+        Commands::InspectAgent(opts) => handle_inspect_agent(opts),
+Commands::RestartAgent(opts) => handle_restart_agent(opts),
+        Commands::Live => {
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            rt.block_on(handle_live());
+        },
     }
 }


### PR DESCRIPTION
- Adds TUI using `tui` and `crossterm` for a live dashboard
- Streams agent CPU/mem/uptime every 2s
- Press `q` to exit cleanly