### PR TITLE
feat(daemon): add dynamic agent daemon for periodic system stats

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -18,5 +18,8 @@ byteorder = "1"
 bytes = "1.10.1"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
+sysinfo = "0.30"
 tui = "0.19"
 crossterm = "0.27"
+chrono = "0.4.41"
+hostname = "0.4.1"

--- a/cli/src/commands/daemon.rs
+++ b/cli/src/commands/daemon.rs
@@ -1,0 +1,73 @@
+use chrono::Utc;
+use serde::Serialize;
+use std::{fs::File, io::Write, path::PathBuf, thread, time::Duration};
+use sysinfo::{System, RefreshKind, CpuRefreshKind, MemoryRefreshKind, LoadAvg};
+use hostname::get;
+use crate::utils::logger::success;
+
+#[derive(Debug, Serialize)]
+struct AgentStatus {
+    id: String,
+    hostname: String,
+    kernel: String,
+    version: String,
+    uptime_secs: u64,
+    cpu_load: [f32; 3],
+    mem_used_mb: u64,
+    mem_total_mb: u64,
+    last_seen: String,
+}
+
+pub async fn handle_daemon() {
+    let agent_id = "agent-001";
+    let run_path = PathBuf::from(format!("/run/eclipta/{}.json", agent_id));
+
+    success(" Starting Eclipta Agent Daemon...");
+
+    let mut sys = System::new_with_specifics(
+        RefreshKind::new()
+            .with_memory(MemoryRefreshKind::everything())
+            .with_cpu(CpuRefreshKind::everything()),
+    );
+
+    loop {
+        sys.refresh_memory();
+        sys.refresh_cpu();
+
+        let hostname = get()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_else(|_| "unknown-host".into());
+
+        let kernel = System::kernel_version().unwrap_or_else(|| "unknown-kernel".into());
+        let version = "0.1.0".to_string();
+        let uptime_secs = System::uptime();
+        let load: LoadAvg = System::load_average();
+        let mem_total_mb = sys.total_memory() / 1024;
+        let mem_used_mb = (sys.total_memory() - sys.available_memory()) / 1024;
+        let now = Utc::now().to_rfc3339();
+
+        let agent = AgentStatus {
+            id: agent_id.to_string(),
+            hostname,
+            kernel,
+            version,
+            uptime_secs,
+            cpu_load: [
+    load.one as f32,
+    load.five as f32,
+    load.fifteen as f32,
+],
+            mem_used_mb,
+            mem_total_mb,
+            last_seen: now,
+        };
+
+        if let Ok(json) = serde_json::to_string_pretty(&agent) {
+            if let Ok(mut file) = File::create(&run_path) {
+                let _ = file.write_all(json.as_bytes());
+            }
+        }
+
+        thread::sleep(Duration::from_secs(5));
+    }
+}

--- a/cli/src/commands/live.rs
+++ b/cli/src/commands/live.rs
@@ -6,7 +6,7 @@ use tui::{
     backend::CrosstermBackend,
     layout::{Constraint, Direction, Layout},
     style::{Color, Modifier, Style},
-    text::{Span, Spans},
+    text::{Span},
     widgets::{Block, Borders, Cell, Row, Table},
     Terminal,
 };

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -9,3 +9,4 @@ pub mod agents_inspect;
 pub mod restart_agent;
 pub mod agent_logs;
 pub mod live;
+pub mod daemon;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -10,8 +10,7 @@ use commands::agents_inspect::{handle_inspect_agent, InspectAgentOptions};
 use commands::restart_agent::{handle_restart_agent, RestartAgentOptions};
 use commands::agent_logs::{handle_agent_logs, AgentLogsOptions};
 use commands::live::handle_live;
-
-
+use commands::daemon::handle_daemon;
 
 #[derive(Parser)]
 #[command(name = "eclipta")]
@@ -34,6 +33,7 @@ enum Commands {
     Agents(AgentOptions),
     AgentLogs(AgentLogsOptions),
     Live,
+    Daemon,
 }
 fn main() {
     let cli = Cli::parse();
@@ -54,10 +54,14 @@ fn main() {
             rt.block_on(handle_agent_logs(opts));
         },
         Commands::InspectAgent(opts) => handle_inspect_agent(opts),
-Commands::RestartAgent(opts) => handle_restart_agent(opts),
+        Commands::RestartAgent(opts) => handle_restart_agent(opts),
         Commands::Live => {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(handle_live());
         },
+        Commands::Daemon => {
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            rt.block_on(handle_daemon());
+        }
     }
 }


### PR DESCRIPTION
Adds a daemon command that writes system metrics (CPU load, memory usage, uptime, etc.) to /run/eclipta/agent-001.json every 5 seconds.

Uses sysinfo and chrono to gather and timestamp system status. Prepared for future extensions like backend sync or WebSocket streaming.