### PR TITLE
feat(monitor): display full agent metrics in TUI (CPU, RAM, Disk, Net…

### DIFF
--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -10,3 +10,4 @@ pub mod restart_agent;
 pub mod agent_logs;
 pub mod live;
 pub mod daemon;
+pub mod monitor;

--- a/cli/src/commands/monitor.rs
+++ b/cli/src/commands/monitor.rs
@@ -1,0 +1,159 @@
+use chrono::{DateTime, Utc};
+use crossterm::{
+    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use serde::Deserialize;
+use std::{fs, io, path::PathBuf, time::Duration};
+use tui::{
+    backend::CrosstermBackend,
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Modifier, Style},
+    text::Span,
+    widgets::{Block, Borders, Cell, Row, Table},
+    Terminal,
+};
+
+#[derive(Deserialize)]
+struct Agent {
+    id: String,
+    hostname: String,
+    kernel: String,
+    version: String,
+    last_seen: String,
+    uptime_secs: u64,
+    cpu_load: [f32; 3],
+    mem_used_mb: u64,
+    mem_total_mb: u64,
+    process_count: u32,
+    disk_used_mb: u64,
+    disk_total_mb: u64,
+    net_rx_kb: u64,
+    net_tx_kb: u64,
+    tcp_connections: u32,
+    alert: bool,
+}
+
+pub async fn handle_monitor() -> io::Result<()> {
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    loop {
+        if event::poll(Duration::from_millis(100))? {
+            if let Event::Key(key) = event::read()? {
+                if key.code == KeyCode::Char('q') {
+                    break;
+                }
+            }
+        }
+
+        let mut agents = Vec::new();
+        if let Ok(files) = fs::read_dir("/run/eclipta") {
+            for entry in files.flatten() {
+                if let Ok(txt) = fs::read_to_string(entry.path()) {
+                    if let Ok(agent) = serde_json::from_str::<Agent>(&txt) {
+                        agents.push(agent);
+                    }
+                }
+            }
+        }
+
+        terminal.draw(|f| {
+            let size = f.size();
+            let chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Percentage(100)].as_ref())
+                .split(size);
+
+            let header = Row::new(
+                vec![
+                    "ID", "Host", "Uptime", "CPU", "Mem", "Disk", "Net", "TCP", "Proc", "Alert",
+                    "Seen",
+                ]
+                .into_iter()
+                .map(|h| Cell::from(Span::styled(h, Style::default().fg(Color::Yellow))))
+                .collect::<Vec<_>>(),
+            );
+
+            let rows: Vec<Row> = agents
+                .iter()
+                .map(|a| {
+                    let cpu = format!(
+                        "{:.1}/{:.1}/{:.1}",
+                        a.cpu_load[0], a.cpu_load[1], a.cpu_load[2]
+                    );
+                    let mem = format!("{} / {}", a.mem_used_mb, a.mem_total_mb);
+                    let disk = format!("{} / {}", a.disk_used_mb, a.disk_total_mb);
+                    let net = format!(
+                        "{:.1}↓ / {:.1}↑",
+                        a.net_rx_kb as f64 / 1024.0,
+                        a.net_tx_kb as f64 / 1024.0
+                    );
+                    let seen = DateTime::parse_from_rfc3339(&a.last_seen)
+                        .map(|dt| dt.with_timezone(&Utc).format("%H:%M:%S").to_string())
+                        .unwrap_or_else(|_| "-".into());
+                    let alert = if a.alert {
+                        Span::styled(
+                            "⚠️",
+                            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+                        )
+                    } else {
+                        Span::raw("✅")
+                    };
+
+                    Row::new(vec![
+                        Cell::from(a.id.clone()),
+                        Cell::from(a.hostname.clone()),
+                        Cell::from(format!("{}s", a.uptime_secs)),
+                        Cell::from(cpu),
+                        Cell::from(mem),
+                        Cell::from(disk),
+                        Cell::from(net),
+                        Cell::from(format!("{}", a.tcp_connections)),
+                        Cell::from(format!("{}", a.process_count)),
+                        Cell::from(alert),
+                        Cell::from(seen),
+                    ])
+                })
+                .collect();
+
+            let table = Table::new(rows)
+                .header(header)
+                .block(
+                    Block::default()
+                        .title("eclipta monitor (press 'q' to quit)")
+                        .borders(Borders::ALL),
+                )
+                .widths(&[
+                    Constraint::Length(10), // ID
+                    Constraint::Length(15), // Hostname
+                    Constraint::Length(8),  // Uptime
+                    Constraint::Length(12), // CPU
+                    Constraint::Length(14), // Mem
+                    Constraint::Length(14), // Disk
+                    Constraint::Length(14), // Net
+                    Constraint::Length(5),  // TCP
+                    Constraint::Length(6),  // Proc
+                    Constraint::Length(6),  // Alert
+                    Constraint::Length(8),  // Last seen
+                ])
+                .column_spacing(1);
+
+            f.render_widget(table, chunks[0]);
+        })?;
+
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+
+    disable_raw_mode()?;
+    execute!(
+        terminal.backend_mut(),
+        LeaveAlternateScreen,
+        DisableMouseCapture
+    )?;
+    Ok(())
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,16 +1,23 @@
 mod commands;
 mod utils;
 
-use clap::{Parser, Subcommand};
-use commands::{welcome::run_welcome, status::run_status, load::handle_load, logs::handle_logs, unload::{handle_unload, UnloadOptions}};
 use crate::commands::logs::LogOptions;
-use commands::inspect::{handle_inspect, InspectOptions};
+use clap::{Parser, Subcommand};
+use commands::agent_logs::{handle_agent_logs, AgentLogsOptions};
 use commands::agents::{handle_agents, AgentOptions};
 use commands::agents_inspect::{handle_inspect_agent, InspectAgentOptions};
-use commands::restart_agent::{handle_restart_agent, RestartAgentOptions};
-use commands::agent_logs::{handle_agent_logs, AgentLogsOptions};
-use commands::live::handle_live;
 use commands::daemon::handle_daemon;
+use commands::inspect::{handle_inspect, InspectOptions};
+use commands::live::handle_live;
+use commands::monitor::handle_monitor;
+use commands::restart_agent::{handle_restart_agent, RestartAgentOptions};
+use commands::{
+    load::handle_load,
+    logs::handle_logs,
+    status::run_status,
+    unload::{handle_unload, UnloadOptions},
+    welcome::run_welcome,
+};
 
 #[derive(Parser)]
 #[command(name = "eclipta")]
@@ -34,6 +41,7 @@ enum Commands {
     AgentLogs(AgentLogsOptions),
     Live,
     Daemon,
+    Monitor,
 }
 fn main() {
     let cli = Cli::parse();
@@ -47,21 +55,25 @@ fn main() {
         Commands::Logs(opts) => {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(handle_logs(opts));
-        },
+        }
         Commands::Agents(opts) => handle_agents(opts),
         Commands::AgentLogs(opts) => {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(handle_agent_logs(opts));
-        },
+        }
         Commands::InspectAgent(opts) => handle_inspect_agent(opts),
         Commands::RestartAgent(opts) => handle_restart_agent(opts),
         Commands::Live => {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(handle_live());
-        },
+        }
         Commands::Daemon => {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(handle_daemon());
+        }
+        Commands::Monitor => {
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            rt.block_on(handle_monitor()).unwrap();
         }
     }
 }

--- a/eclipta-agents/src/main.rs
+++ b/eclipta-agents/src/main.rs
@@ -1,7 +1,9 @@
-use std::fs;
+use std::{fs, thread, time::Duration};
+use std::fs::File;
+use std::io::Write;
 use std::path::PathBuf;
 use std::process::Command;
-use std::{thread, time};
+
 use chrono::Utc;
 use serde::Serialize;
 
@@ -13,35 +15,67 @@ struct AgentStatus {
     version: String,
     last_seen: String,
     uptime_secs: u64,
+    cpu_load: [f32; 3],
+    mem_used_mb: u64,
+    mem_total_mb: u64,
+    process_count: usize,
+    disk_used_mb: u64,
+    disk_total_mb: u64,
+    net_rx_kb: u64,
+    net_tx_kb: u64,
+    tcp_connections: usize,
+    alert: bool,
 }
 
 fn main() {
-    let interval = time::Duration::from_secs(5);
     let agent_id = "agent-001";
+    let interval = Duration::from_secs(5);
+    let status_dir = PathBuf::from("/run/eclipta");
+    fs::create_dir_all(&status_dir).ok();
 
     loop {
         let hostname = get_hostname();
         let kernel = get_kernel();
-        let version = "v0.1.0";
+        let version = "v0.1.0".to_string();
         let now = Utc::now().to_rfc3339();
         let uptime_secs = get_uptime_secs();
+
+        let cpu_load = get_cpu_load();
+        let (mem_used_mb, mem_total_mb) = get_memory_mb();
+        let (disk_used_mb, disk_total_mb) = get_disk_usage();
+        let (net_rx_kb, net_tx_kb) = get_network_io();
+        let process_count = get_process_count();
+        let tcp_connections = get_tcp_connection_count();
+
+        let alert = should_alert(&cpu_load, mem_used_mb, mem_total_mb);
 
         let status = AgentStatus {
             id: agent_id.to_string(),
             hostname,
             kernel,
-            version: version.to_string(),
+            version,
             last_seen: now,
             uptime_secs,
+            cpu_load,
+            mem_used_mb,
+            mem_total_mb,
+            process_count,
+            disk_used_mb,
+            disk_total_mb,
+            net_rx_kb,
+            net_tx_kb,
+            tcp_connections,
+            alert,
         };
 
-        let status_dir = PathBuf::from("/run/eclipta");
-        fs::create_dir_all(&status_dir).ok();
+        if let Ok(json) = serde_json::to_string_pretty(&status) {
+            let path = status_dir.join(format!("{agent_id}.json"));
+            if let Ok(mut file) = File::create(path) {
+                let _ = file.write_all(json.as_bytes());
+                println!("✅ Agent heartbeat written.");
+            }
+        }
 
-        let json = serde_json::to_string_pretty(&status).unwrap();
-        fs::write(status_dir.join("agent-001.json"), json).unwrap();
-
-        println!("Agent heartbeat written.");
         thread::sleep(interval);
     }
 }
@@ -66,4 +100,99 @@ fn get_uptime_secs() -> u64 {
         .ok()
         .and_then(|s| s.split('.').next().map(|v| v.parse().unwrap_or(0)))
         .unwrap_or(0)
+}
+
+fn get_cpu_load() -> [f32; 3] {
+    fs::read_to_string("/proc/loadavg")
+        .ok()
+        .and_then(|s| {
+            let parts: Vec<&str> = s.split_whitespace().collect();
+            if parts.len() >= 3 {
+                Some([
+                    parts[0].parse().unwrap_or(0.0),
+                    parts[1].parse().unwrap_or(0.0),
+                    parts[2].parse().unwrap_or(0.0),
+                ])
+            } else {
+                None
+            }
+        })
+        .unwrap_or([0.0, 0.0, 0.0])
+}
+
+fn get_memory_mb() -> (u64, u64) {
+    let data = fs::read_to_string("/proc/meminfo").unwrap_or_default();
+    let mut total: u64 = 0;
+    let mut free: u64 = 0;
+
+    for line in data.lines() {
+        if line.starts_with("MemTotal:") {
+            total = line.split_whitespace().nth(1).unwrap_or("0").parse().unwrap_or(0);
+        } else if line.starts_with("MemAvailable:") {
+            free = line.split_whitespace().nth(1).unwrap_or("0").parse().unwrap_or(0);
+        }
+    }
+
+    let used = total.saturating_sub(free);
+    (used / 1024, total / 1024) // return in MB
+}
+
+
+fn get_disk_usage() -> (u64, u64) {
+    let output = Command::new("df").arg("-BM").arg("/").output();
+    if let Ok(out) = output {
+        let lines = String::from_utf8_lossy(&out.stdout);
+        for line in lines.lines().skip(1) {
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            if parts.len() >= 5 {
+                let total = parts[1].trim_end_matches('M').parse().unwrap_or(0);
+                let used = parts[2].trim_end_matches('M').parse().unwrap_or(0);
+                return (used, total);
+            }
+        }
+    }
+    (0, 0)
+}
+
+fn get_network_io() -> (u64, u64) {
+    let data = fs::read_to_string("/proc/net/dev").unwrap_or_default();
+    let mut rx = 0;
+    let mut tx = 0;
+    for line in data.lines().skip(2) {
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.len() >= 17 {
+            rx += parts[1].parse::<u64>().unwrap_or(0); // RX bytes
+            tx += parts[9].parse::<u64>().unwrap_or(0); // TX bytes
+        }
+    }
+    (rx / 1024, tx / 1024) // Return in KB
+}
+
+fn get_process_count() -> usize {
+    let entries = match fs::read_dir("/proc") {
+        Ok(entries) => entries,
+        Err(_) => return 0,
+    };
+
+    entries
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            e.file_name()
+                .to_string_lossy()
+                .chars()
+                .all(|c| c.is_ascii_digit())
+        })
+        .count()
+}
+
+
+fn get_tcp_connection_count() -> usize {
+    fs::read_to_string("/proc/net/tcp")
+        .map(|content| content.lines().skip(1).count())
+        .unwrap_or(0)
+}
+
+fn should_alert(cpu: &[f32; 3], used: u64, total: u64) -> bool {
+    let mem_percent = used as f32 / total as f32 * 100.0;
+    cpu[0] > 2.0 || mem_percent > 90.0
 }


### PR DESCRIPTION
…, Alerts)

- Updated the eclipta monitor command to show full agent system metrics.
- Added columns for:
  - Process count
  - Disk usage (used / total in MB)
  - Network RX/TX (in KB)
  - TCP connection count
  - Alert status (highlighted if true)
- Improved timestamp formatting using RFC3339 and converted to UTC.
- This update enhances visibility for real-time system health in the terminal dashboard.