### PR TITLE
feat(cli): add `watch-cpu` command with optional --agent-id filter

### DIFF
--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -12,3 +12,4 @@ pub mod live;
 pub mod daemon;
 pub mod monitor;
 pub mod ping_all;
+pub mod watch_cpu;

--- a/cli/src/commands/watch_cpu.rs
+++ b/cli/src/commands/watch_cpu.rs
@@ -1,0 +1,57 @@
+use std::{fs, time::Duration};
+use tokio::time::sleep;
+use serde::Deserialize;
+use chrono::Local;
+use clap::Args;
+
+#[derive(Deserialize)]
+struct AgentCpuLoad {
+    id: String,
+    cpu_load: Option<[f32; 3]>,
+    last_seen: String,
+}
+
+#[derive(Args)]
+pub struct WatchCpuOptions {
+    #[arg(long)]
+    pub agent_id: Option<String>,
+}
+
+pub async fn handle_watch_cpu(opts: WatchCpuOptions) -> anyhow::Result<()> {
+    let agent_filter = opts.agent_id;
+
+    println!("Watching CPU load{} (Ctrl+C to quit)...",
+        agent_filter
+            .as_ref()
+            .map(|id| format!(" for agent '{}'", id))
+            .unwrap_or_default()
+    );
+
+    loop {
+        let paths = fs::read_dir("/run/eclipta")?;
+        println!("\n{}", Local::now().format("%H:%M:%S"));
+
+        for entry in paths.flatten() {
+            if let Ok(content) = fs::read_to_string(entry.path()) {
+                if let Ok(agent) = serde_json::from_str::<AgentCpuLoad>(&content) {
+                    if let Some(ref filter) = agent_filter {
+                        if agent.id != *filter {
+                            continue;
+                        }
+                    }
+
+                    if let Some(load) = agent.cpu_load {
+                        println!(
+                            "{} | CPU Load: {:.1} / {:.1} / {:.1} | Seen: {}",
+                            agent.id,
+                            load[0], load[1], load[2],
+                            agent.last_seen
+                        );
+                    }
+                }
+            }
+        }
+
+        sleep(Duration::from_secs(3)).await;
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2,23 +2,24 @@ mod commands;
 mod utils;
 
 use crate::commands::logs::LogOptions;
-use clap::{ Parser, Subcommand };
-use commands::agent_logs::{ handle_agent_logs, AgentLogsOptions };
-use commands::agents::{ handle_agents, AgentOptions };
-use commands::agents_inspect::{ handle_inspect_agent, InspectAgentOptions };
+use clap::{Parser, Subcommand};
+use commands::agent_logs::{handle_agent_logs, AgentLogsOptions};
+use commands::agents::{handle_agents, AgentOptions};
+use commands::agents_inspect::{handle_inspect_agent, InspectAgentOptions};
 use commands::daemon::handle_daemon;
-use commands::inspect::{ handle_inspect, InspectOptions };
+use commands::inspect::{handle_inspect, InspectOptions};
 use commands::live::handle_live;
 use commands::monitor::handle_monitor;
-use commands::restart_agent::{ handle_restart_agent, RestartAgentOptions };
+use commands::ping_all;
+use commands::restart_agent::{handle_restart_agent, RestartAgentOptions};
+use commands::watch_cpu::{handle_watch_cpu, WatchCpuOptions};
 use commands::{
     load::handle_load,
     logs::handle_logs,
     status::run_status,
-    unload::{ handle_unload, UnloadOptions },
+    unload::{handle_unload, UnloadOptions},
     welcome::run_welcome,
 };
-use commands::ping_all;
 
 #[derive(Parser)]
 #[command(name = "eclipta")]
@@ -44,6 +45,7 @@ enum Commands {
     Daemon,
     Monitor,
     PingAll,
+    WatchCpu(WatchCpuOptions),
 }
 fn main() {
     let cli = Cli::parse();
@@ -80,6 +82,10 @@ fn main() {
         Commands::PingAll => {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(ping_all::handle_ping_all());
+        }
+        Commands::WatchCpu(opts) => {
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            rt.block_on(handle_watch_cpu(opts)).unwrap();
         }
     }
 }


### PR DESCRIPTION
This commit introduces the `eclipta watch-cpu` command, allowing real-time monitoring of CPU load for all agents or a specific one via the `--agent-id` flag.

Features:
- Parses `/run/eclipta/*.json` files to extract CPU metrics
- Supports filtering by agent ID
- Displays 1/5/15 minute load averages
- Auto-refreshes every 3 seconds

This is useful for DevOps engineers to monitor system load from the CLI.