### PR TITLE
feat(cli): add `config` command to inspect agent configuration

### DIFF
--- a/cli/src/commands/config.rs
+++ b/cli/src/commands/config.rs
@@ -1,16 +1,30 @@
 use clap::Args;
-use std::{fs, path::PathBuf};
-use anyhow::Result;
-use serde::Deserialize;
+use std::{collections::HashMap, fs, path::PathBuf};
+use anyhow::{anyhow, Result};
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Args)]
+#[derive(Args)]
 pub struct ConfigOptions {
     #[arg(long)]
     pub agent: String,
+
+    #[arg(long)]
+    pub get: Option<String>,
+
+    #[arg(long)]
+    pub set: Option<String>,
+
+    #[arg(long)]
+    pub list: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct AgentSettings {
+    pub settings: HashMap<String, String>,
 }
 
 #[derive(Debug, Deserialize)]
-struct AgentConfig {
+struct AgentStatus {
     id: String,
     hostname: String,
     kernel: String,
@@ -30,9 +44,12 @@ struct AgentConfig {
 }
 
 pub async fn handle_config(opts: ConfigOptions) -> Result<()> {
-    let path = PathBuf::from(format!("/run/eclipta/{}.json", opts.agent));
-    let data = fs::read_to_string(&path)?;
-    let agent: AgentConfig = serde_json::from_str(&data)?;
+    let runtime_path = PathBuf::from(format!("/run/eclipta/{}.json", opts.agent));
+    let config_path = PathBuf::from(format!("/etc/eclipta/agent-{}.conf.json", opts.agent));
+
+    // Load runtime status from /run/eclipta/<agent>.json
+    let status_data = fs::read_to_string(&runtime_path)?;
+    let agent: AgentStatus = serde_json::from_str(&status_data)?;
 
     println!("Agent Configuration for '{}':\n", agent.id);
     println!("Hostname      : {}", agent.hostname);
@@ -66,7 +83,42 @@ pub async fn handle_config(opts: ConfigOptions) -> Result<()> {
     }
 
     if let Some(alert) = agent.alert {
-        println!("Alert       : {}", if alert { "YES" } else { "No" });
+        println!("Alert         : {}", if alert { "YES" } else { "No" });
+    }
+
+    // Load config from /etc/eclipta/agent-xxx.conf.json
+    let mut config: AgentSettings = if config_path.exists() {
+        let data = fs::read_to_string(&config_path)?;
+        serde_json::from_str(&data).unwrap_or_default()
+    } else {
+        AgentSettings::default()
+    };
+
+    if opts.list {
+        println!("\nAgent Saved Settings:");
+        for (key, value) in &config.settings {
+            println!("{} = {}", key, value);
+        }
+    }
+
+    if let Some(key) = opts.get {
+        if let Some(val) = config.settings.get(&key) {
+            println!("\n{} = {}", key, val);
+        } else {
+            println!("\nKey '{}' not found", key);
+        }
+    }
+
+    if let Some(kv) = opts.set {
+        let parts: Vec<&str> = kv.splitn(2, '=').collect();
+        if parts.len() != 2 {
+            return Err(anyhow!("Invalid format. Use --set key=value"));
+        }
+
+        config.settings.insert(parts[0].to_string(), parts[1].to_string());
+        fs::create_dir_all("/etc/eclipta")?;
+        fs::write(&config_path, serde_json::to_string_pretty(&config)?)?;
+        println!("\nUpdated config: {} = {}", parts[0], parts[1]);
     }
 
     Ok(())

--- a/cli/src/commands/config.rs
+++ b/cli/src/commands/config.rs
@@ -1,0 +1,73 @@
+use clap::Args;
+use std::{fs, path::PathBuf};
+use anyhow::Result;
+use serde::Deserialize;
+
+#[derive(Debug, Args)]
+pub struct ConfigOptions {
+    #[arg(long)]
+    pub agent: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct AgentConfig {
+    id: String,
+    hostname: String,
+    kernel: String,
+    version: String,
+    last_seen: String,
+    uptime_secs: u64,
+    cpu_load: Option<[f32; 3]>,
+    mem_used_mb: Option<u64>,
+    mem_total_mb: Option<u64>,
+    process_count: Option<u64>,
+    disk_used_mb: Option<u64>,
+    disk_total_mb: Option<u64>,
+    net_rx_kb: Option<u64>,
+    net_tx_kb: Option<u64>,
+    tcp_connections: Option<u64>,
+    alert: Option<bool>,
+}
+
+pub async fn handle_config(opts: ConfigOptions) -> Result<()> {
+    let path = PathBuf::from(format!("/run/eclipta/{}.json", opts.agent));
+    let data = fs::read_to_string(&path)?;
+    let agent: AgentConfig = serde_json::from_str(&data)?;
+
+    println!("Agent Configuration for '{}':\n", agent.id);
+    println!("Hostname      : {}", agent.hostname);
+    println!("Kernel        : {}", agent.kernel);
+    println!("Version       : {}", agent.version);
+    println!("Uptime (secs) : {}", agent.uptime_secs);
+    println!("Last Seen     : {}", agent.last_seen);
+
+    if let Some(cpu) = agent.cpu_load {
+        println!("CPU Load      : {:.1} / {:.1} / {:.1}", cpu[0], cpu[1], cpu[2]);
+    }
+
+    if let (Some(used), Some(total)) = (agent.mem_used_mb, agent.mem_total_mb) {
+        println!("Memory        : {} MB / {} MB", used, total);
+    }
+
+    if let Some(proc) = agent.process_count {
+        println!("Processes     : {}", proc);
+    }
+
+    if let (Some(du), Some(dt)) = (agent.disk_used_mb, agent.disk_total_mb) {
+        println!("Disk Usage    : {} MB / {} MB", du, dt);
+    }
+
+    if let (Some(rx), Some(tx)) = (agent.net_rx_kb, agent.net_tx_kb) {
+        println!("Network RX/TX : {} KB / {} KB", rx, tx);
+    }
+
+    if let Some(tc) = agent.tcp_connections {
+        println!("TCP Conns     : {}", tc);
+    }
+
+    if let Some(alert) = agent.alert {
+        println!("Alert       : {}", if alert { "YES" } else { "No" });
+    }
+
+    Ok(())
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -13,3 +13,4 @@ pub mod daemon;
 pub mod monitor;
 pub mod ping_all;
 pub mod watch_cpu;
+pub mod config;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2,22 +2,23 @@ mod commands;
 mod utils;
 
 use crate::commands::logs::LogOptions;
-use clap::{Parser, Subcommand};
-use commands::agent_logs::{handle_agent_logs, AgentLogsOptions};
-use commands::agents::{handle_agents, AgentOptions};
-use commands::agents_inspect::{handle_inspect_agent, InspectAgentOptions};
+use clap::{ Parser, Subcommand };
+use commands::agent_logs::{ handle_agent_logs, AgentLogsOptions };
+use commands::agents::{ handle_agents, AgentOptions };
+use commands::agents_inspect::{ handle_inspect_agent, InspectAgentOptions };
 use commands::daemon::handle_daemon;
-use commands::inspect::{handle_inspect, InspectOptions};
+use commands::inspect::{ handle_inspect, InspectOptions };
 use commands::live::handle_live;
 use commands::monitor::handle_monitor;
 use commands::ping_all;
-use commands::restart_agent::{handle_restart_agent, RestartAgentOptions};
-use commands::watch_cpu::{handle_watch_cpu, WatchCpuOptions};
+use commands::restart_agent::{ handle_restart_agent, RestartAgentOptions };
+use commands::config::{ handle_config, ConfigOptions };
+use commands::watch_cpu::{ handle_watch_cpu, WatchCpuOptions };
 use commands::{
     load::handle_load,
     logs::handle_logs,
     status::run_status,
-    unload::{handle_unload, UnloadOptions},
+    unload::{ handle_unload, UnloadOptions },
     welcome::run_welcome,
 };
 
@@ -46,6 +47,7 @@ enum Commands {
     Monitor,
     PingAll,
     WatchCpu(WatchCpuOptions),
+    Config(ConfigOptions),
 }
 fn main() {
     let cli = Cli::parse();
@@ -86,6 +88,10 @@ fn main() {
         Commands::WatchCpu(opts) => {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(handle_watch_cpu(opts)).unwrap();
+        }
+        Commands::Config(opts) => {
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            rt.block_on(handle_config(opts)).unwrap();
         }
     }
 }


### PR DESCRIPTION
Added a new `eclipta config --agent <agent_id>` command that reads agent metadata from `/run/eclipta/*.json`.

Includes:
- Hostname, kernel, version
- Uptime and last seen timestamp
- Optional fields like CPU, memory, disk, network, and alerts

This is useful for quickly inspecting agent status in a readable format.