### PR TITLE
cli: add `alerts` command to list active agent alerts

### DIFF
--- a/cli/src/commands/alerts.rs
+++ b/cli/src/commands/alerts.rs
@@ -1,0 +1,48 @@
+use std::{fs, path::PathBuf};
+use anyhow::Result;
+use serde::Deserialize;
+use chrono::{DateTime, Utc, Duration};
+
+#[derive(Debug, Deserialize)]
+struct AgentStatus {
+    id: String,
+    hostname: String,
+    alert: Option<bool>,
+    last_seen: Option<String>,
+}
+
+pub async fn handle_alerts() -> Result<()> {
+    let dir = PathBuf::from("/run/eclipta");
+    let mut alerted_agents = Vec::new();
+    let now = Utc::now();
+
+    if let Ok(entries) = fs::read_dir(&dir) {
+        for entry in entries.flatten() {
+            if let Ok(content) = fs::read_to_string(entry.path()) {
+                if let Ok(agent) = serde_json::from_str::<AgentStatus>(&content) {
+                    if let (Some(true), Some(last_seen_str)) = (agent.alert, &agent.last_seen) {
+                        if let Ok(last_seen) = DateTime::parse_from_rfc3339(last_seen_str) {
+                            let last_seen = last_seen.with_timezone(&Utc);
+                            let age = now.signed_duration_since(last_seen);
+
+                            if age < Duration::seconds(15) {
+                                alerted_agents.push((agent.id, agent.hostname, last_seen_str.clone()));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if alerted_agents.is_empty() {
+        println!("No agents are currently in alert state.");
+    } else {
+        println!("Alerted Agents (last seen < 15s):\n");
+        for (id, hostname, last_seen) in alerted_agents {
+            println!("- [{}] {} | Last Seen: {}", id, hostname, last_seen);
+        }
+    }
+
+    Ok(())
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -14,3 +14,4 @@ pub mod monitor;
 pub mod ping_all;
 pub mod watch_cpu;
 pub mod config;
+pub mod alerts;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -11,6 +11,7 @@ use commands::inspect::{ handle_inspect, InspectOptions };
 use commands::live::handle_live;
 use commands::monitor::handle_monitor;
 use commands::ping_all;
+use commands::alerts::handle_alerts;
 use commands::restart_agent::{ handle_restart_agent, RestartAgentOptions };
 use commands::config::{ handle_config, ConfigOptions };
 use commands::watch_cpu::{ handle_watch_cpu, WatchCpuOptions };
@@ -48,6 +49,7 @@ enum Commands {
     PingAll,
     WatchCpu(WatchCpuOptions),
     Config(ConfigOptions),
+    Alerts,
 }
 fn main() {
     let cli = Cli::parse();
@@ -92,6 +94,10 @@ fn main() {
         Commands::Config(opts) => {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(handle_config(opts)).unwrap();
+        }
+        Commands::Alerts => {
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            rt.block_on(handle_alerts()).unwrap();
         }
     }
 }


### PR DESCRIPTION
- Introduced new `eclipta alerts` command.
- Displays agents with `alert: true` and last_seen within 15 seconds.
- Filters out stale or inactive agents.
- Enhances real-time visibility into system alerts.