### PR TITLE
feat(cli): add kill-agent command to terminate agent by PID

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,7 +10,7 @@ color-eyre = "0.6"
 tracing-subscriber = "0.3"
 figlet-rs = "0.1"
 console = "0.15"
-nix = { version = "0.30", features = ["user"] }
+nix = { version = "0.30", features = ["user", "signal", "process"] }
 anyhow = "1"
 log = "0.4"
 tokio = { version = "1.38", features = ["rt-multi-thread", "time", "signal", "fs", "io-util"] }

--- a/cli/src/commands/kill_agent.rs
+++ b/cli/src/commands/kill_agent.rs
@@ -1,0 +1,31 @@
+use clap::Args;
+use std::{fs, path::PathBuf};
+use anyhow::{Result, Context};
+
+#[derive(Args)]
+pub struct KillAgentOptions {
+    #[arg(long)]
+    pub agent: String,
+}
+
+pub fn handle_kill_agent(opts: KillAgentOptions) -> Result<()> {
+    let pid_path = PathBuf::from(format!("/run/eclipta/{}.pid", opts.agent));
+    
+    let pid_str = fs::read_to_string(&pid_path)
+        .with_context(|| format!("Failed to read PID file for agent '{}'", opts.agent))?;
+
+    let pid: i32 = pid_str.trim().parse()
+        .with_context(|| format!("Invalid PID found in {}", pid_path.display()))?;
+
+    println!("Sending SIGTERM to agent '{}' (PID {})", opts.agent, pid);
+    
+    // Send SIGTERM to the process
+    nix::sys::signal::kill(
+        nix::unistd::Pid::from_raw(pid),
+        nix::sys::signal::Signal::SIGTERM,
+    ).with_context(|| format!("Failed to send SIGTERM to PID {}", pid))?;
+
+    println!("Kill signal sent successfully.");
+
+    Ok(())
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -15,3 +15,4 @@ pub mod ping_all;
 pub mod watch_cpu;
 pub mod config;
 pub mod alerts;
+pub mod kill_agent;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -15,6 +15,7 @@ use commands::alerts::handle_alerts;
 use commands::restart_agent::{ handle_restart_agent, RestartAgentOptions };
 use commands::config::{ handle_config, ConfigOptions };
 use commands::watch_cpu::{ handle_watch_cpu, WatchCpuOptions };
+use commands::kill_agent::{handle_kill_agent, KillAgentOptions};
 use commands::{
     load::handle_load,
     logs::handle_logs,
@@ -50,6 +51,7 @@ enum Commands {
     WatchCpu(WatchCpuOptions),
     Config(ConfigOptions),
     Alerts,
+    KillAgent(KillAgentOptions),
 }
 fn main() {
     let cli = Cli::parse();
@@ -99,5 +101,7 @@ fn main() {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(handle_alerts()).unwrap();
         }
+        Commands::KillAgent(opts) => handle_kill_agent(opts).unwrap(),
+        
     }
 }


### PR DESCRIPTION
Implements `eclipta kill-agent --agent <id>` to gracefully send SIGTERM to a running agent process.

- Relies on `/run/eclipta/<agent-id>.pid` to fetch the process ID
- Uses nix crate to send signal
- Provides user feedback and error handling
- Requires agent to write PID on startup

Example:
  eclipta kill-agent --agent agent-001