### PR TITLE
feat(cli): add `update-agent` command to deploy new agent binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,8 +424,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "eclipta-agents"
-version = "0.1.0"
+name = "eclipta-agent"
+version = "0.2.1"
 dependencies = [
  "chrono",
  "hostname 0.3.1",

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -16,3 +16,4 @@ pub mod watch_cpu;
 pub mod config;
 pub mod alerts;
 pub mod kill_agent;
+pub mod update_agent;

--- a/cli/src/commands/update_agent.rs
+++ b/cli/src/commands/update_agent.rs
@@ -1,0 +1,51 @@
+use clap::Args;
+use anyhow::{Result, Context};
+use std::{fs, path::Path, process::Command};
+
+#[derive(Args)]
+pub struct UpdateAgentOptions {
+    #[arg(long)]
+    pub agent: String,
+
+    #[arg(long)]
+    pub version: Option<String>,
+
+    #[arg(long)]
+    pub force: bool,
+
+    #[arg(long)]
+    pub restart: bool,
+}
+
+pub async fn handle_update_agent(opts: UpdateAgentOptions) -> Result<()> {
+    let agent_bin_path = format!("/opt/eclipta/agents/{}/eclipta-agent", opts.agent);
+    let new_bin_path = match &opts.version {
+        Some(v) => format!("/opt/eclipta/releases/{}/eclipta-agent", v),
+        None => "/opt/eclipta/releases/latest/eclipta-agent".into(),
+    };
+
+    println!("Updating agent '{}'...", opts.agent);
+    println!(" - Current path: {}", agent_bin_path);
+    println!(" - New version:  {}", new_bin_path);
+
+    if !Path::new(&new_bin_path).exists() {
+        anyhow::bail!("New agent binary not found at: {}", new_bin_path);
+    }
+
+    // Replace binary
+    fs::copy(&new_bin_path, &agent_bin_path)
+        .with_context(|| format!("Failed to copy new agent binary to {}", agent_bin_path))?;
+
+    println!(" Agent '{}' binary updated.", opts.agent);
+
+    // Optional restart
+    if opts.restart {
+        println!(" Restarting agent '{}'", opts.agent);
+        Command::new("systemctl")
+            .args(&["restart", &format!("eclipta-agent@{}", opts.agent)])
+            .status()
+            .context("Failed to restart agent service")?;
+    }
+
+    Ok(())
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -15,7 +15,8 @@ use commands::alerts::handle_alerts;
 use commands::restart_agent::{ handle_restart_agent, RestartAgentOptions };
 use commands::config::{ handle_config, ConfigOptions };
 use commands::watch_cpu::{ handle_watch_cpu, WatchCpuOptions };
-use commands::kill_agent::{handle_kill_agent, KillAgentOptions};
+use commands::kill_agent::{ handle_kill_agent, KillAgentOptions };
+use commands::update_agent::{ handle_update_agent, UpdateAgentOptions };
 use commands::{
     load::handle_load,
     logs::handle_logs,
@@ -52,6 +53,7 @@ enum Commands {
     Config(ConfigOptions),
     Alerts,
     KillAgent(KillAgentOptions),
+    UpdateAgent(UpdateAgentOptions),
 }
 fn main() {
     let cli = Cli::parse();
@@ -102,6 +104,9 @@ fn main() {
             rt.block_on(handle_alerts()).unwrap();
         }
         Commands::KillAgent(opts) => handle_kill_agent(opts).unwrap(),
-        
+        Commands::UpdateAgent(opts) => {
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            rt.block_on(handle_update_agent(opts)).unwrap();
+        }
     }
 }

--- a/eclipta-agents/Cargo.toml
+++ b/eclipta-agents/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "eclipta-agents"
-version = "0.1.0"
+name = "eclipta-agent"
+version = "0.2.1"
 edition = "2021"
 
 [dependencies]
@@ -8,3 +8,7 @@ chrono = "0.4"
 hostname = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[[bin]]
+name = "eclipta-agent"
+path = "src/main.rs"

--- a/eclipta-agents/src/main.rs
+++ b/eclipta-agents/src/main.rs
@@ -36,7 +36,7 @@ fn main() {
     loop {
         let hostname = get_hostname();
         let kernel = get_kernel();
-        let version = "v0.1.0".to_string();
+        let version = env!("CARGO_PKG_VERSION").to_string();
         let now = Utc::now().to_rfc3339();
         let uptime_secs = get_uptime_secs();
 


### PR DESCRIPTION
- Supports --agent, --version, --force, and --restart flags
- Automatically copies binaries from release dir to agent dir
- Can restart agent service using systemd