### PR TITLE
feat: add `version` command to show CLI or agent version

### DIFF
--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -17,3 +17,4 @@ pub mod config;
 pub mod alerts;
 pub mod kill_agent;
 pub mod update_agent;
+pub mod version;

--- a/cli/src/commands/version.rs
+++ b/cli/src/commands/version.rs
@@ -1,0 +1,42 @@
+use std::{fs, path::PathBuf};
+use anyhow::Result;
+use clap::Args;
+use serde::Deserialize;
+
+#[derive(Args)]
+pub struct VersionOptions {
+    #[arg(long)]
+    pub agent: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AgentVersionInfo {
+    id: String,
+    version: String,
+}
+
+pub async fn handle_version(opts: VersionOptions) -> Result<()> {
+    if let Some(agent_id) = opts.agent {
+        let path = PathBuf::from(format!("/run/eclipta/{}.json", agent_id));
+
+        if !path.exists() {
+            println!("Could not find version info for agent '{}'", agent_id);
+            return Ok(());
+        }
+
+        let contents = fs::read_to_string(&path)?;
+        let agent_info: AgentVersionInfo = match serde_json::from_str(&contents) {
+            Ok(info) => info,
+            Err(_) => {
+                println!("Malformed JSON for agent '{}'", agent_id);
+                return Ok(());
+            }
+        };
+
+        println!(" Agent '{}' version: {}", agent_info.id, agent_info.version);
+    } else {
+        println!(" eclipta CLI version: {}", env!("CARGO_PKG_VERSION"));
+    }
+
+    Ok(())
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -17,6 +17,7 @@ use commands::config::{ handle_config, ConfigOptions };
 use commands::watch_cpu::{ handle_watch_cpu, WatchCpuOptions };
 use commands::kill_agent::{ handle_kill_agent, KillAgentOptions };
 use commands::update_agent::{ handle_update_agent, UpdateAgentOptions };
+use commands::version::{ handle_version, VersionOptions };
 use commands::{
     load::handle_load,
     logs::handle_logs,
@@ -54,6 +55,7 @@ enum Commands {
     Alerts,
     KillAgent(KillAgentOptions),
     UpdateAgent(UpdateAgentOptions),
+    Version(VersionOptions),
 }
 fn main() {
     let cli = Cli::parse();
@@ -107,6 +109,10 @@ fn main() {
         Commands::UpdateAgent(opts) => {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(handle_update_agent(opts)).unwrap();
+        }
+        Commands::Version(opts) => {
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            rt.block_on(handle_version(opts)).unwrap();
         }
     }
 }


### PR DESCRIPTION
- Supports `eclipta version` to show CLI binary version from CARGO_PKG_VERSION
- Supports `eclipta version --agent <id>` to show agent's version from /run/eclipta/<id>.json