### PR TITLE
feat(cli): add sync-agents command to aggregate active agent snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -21,6 +21,6 @@ serde = { version = "1.0", features = ["derive"] }
 sysinfo = "0.30"
 tui = "0.19"
 crossterm = "0.27"
-chrono = "0.4.41"
+chrono = { version = "0.4", features = ["serde"] }
 hostname = "0.4.1"
 humantime = "2.1"

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -18,3 +18,4 @@ pub mod alerts;
 pub mod kill_agent;
 pub mod update_agent;
 pub mod version;
+pub mod sync_agents;

--- a/cli/src/commands/sync_agents.rs
+++ b/cli/src/commands/sync_agents.rs
@@ -1,0 +1,55 @@
+use std::{fs, path::PathBuf};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use clap::Args;
+use anyhow::Result;
+
+#[derive(Args)]
+pub struct SyncAgentsOptions {}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct AgentSnapshot {
+    pub id: String,
+    pub hostname: String,
+    pub kernel: String,
+    pub version: String,
+    pub last_seen: DateTime<Utc>,
+    pub uptime_secs: u64,
+    pub cpu_load: [f32; 3],
+    pub mem_used_mb: u64,
+    pub mem_total_mb: u64,
+    pub process_count: u64,
+    pub disk_used_mb: u64,
+    pub disk_total_mb: u64,
+    pub net_rx_kb: u64,
+    pub net_tx_kb: u64,
+    pub tcp_connections: u64,
+    pub alert: bool
+}
+
+pub async fn handle_sync_agents(_: SyncAgentsOptions) -> Result<()> {
+    let mut snapshots = Vec::new();
+    let dir = PathBuf::from("/run/eclipta");
+
+    if dir.exists() {
+        for entry in fs::read_dir(&dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().map(|e| e == "json").unwrap_or(false) {
+                let raw = fs::read_to_string(&path)?;
+                match serde_json::from_str::<AgentSnapshot>(&raw) {
+                    Ok(snapshot) => snapshots.push(snapshot),
+                    Err(e) => eprintln!("⚠️ Failed to parse {}: {}", path.display(), e),
+                }
+            }
+        }
+    }
+
+    let out_path = PathBuf::from("/etc/eclipta/agents/snapshot.json");
+    fs::create_dir_all(out_path.parent().unwrap())?;
+    fs::write(&out_path, serde_json::to_string_pretty(&snapshots)?)?;
+
+    println!("✅ Synced {} agents to {}", snapshots.len(), out_path.display());
+
+    Ok(())
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -18,6 +18,7 @@ use commands::watch_cpu::{ handle_watch_cpu, WatchCpuOptions };
 use commands::kill_agent::{ handle_kill_agent, KillAgentOptions };
 use commands::update_agent::{ handle_update_agent, UpdateAgentOptions };
 use commands::version::{ handle_version, VersionOptions };
+use commands::sync_agents::{ handle_sync_agents, SyncAgentsOptions };
 use commands::{
     load::handle_load,
     logs::handle_logs,
@@ -56,6 +57,7 @@ enum Commands {
     KillAgent(KillAgentOptions),
     UpdateAgent(UpdateAgentOptions),
     Version(VersionOptions),
+    SyncAgents(SyncAgentsOptions),
 }
 fn main() {
     let cli = Cli::parse();
@@ -113,6 +115,10 @@ fn main() {
         Commands::Version(opts) => {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(handle_version(opts)).unwrap();
+        }
+        Commands::SyncAgents(opts) => {
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            rt.block_on(handle_sync_agents(opts)).unwrap();
         }
     }
 }


### PR DESCRIPTION
This adds a new CLI command `eclipta sync-agents` that dynamically scans all agent status files under `/run/eclipta/*.json`, parses their live system metrics, and saves a unified snapshot to `/etc/eclipta/agents/snapshot.json`.

The command supports syncing multiple agents and records key metrics including uptime, CPU load, memory usage, disk/network stats, and alert flags. Each synced snapshot also includes the `last_seen` timestamp to help identify stale or inactive agents.

This command enables central observability tooling to query and display current system-wide agent health in one place, acting as a local collector layer.