### PR TITLE
feat(api): add dynamic /agents endpoint to serve JSON agent data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ dependencies = [
  "log",
  "object",
  "once_cell",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -198,7 +198,7 @@ dependencies = [
  "hashbrown",
  "log",
  "object",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -206,8 +206,10 @@ name = "backend"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "glob",
  "hyper",
  "hyper-util",
+ "jsonwebtoken",
  "pam",
  "serde",
  "serde_json",
@@ -232,6 +234,12 @@ dependencies = [
  "rustc-demangle",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -482,6 +490,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "eclipta-agent"
 version = "0.2.1"
 dependencies = [
@@ -612,10 +629,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "hashbrown"
@@ -812,6 +848,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -937,6 +988,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,6 +1101,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
+dependencies = [
+ "base64",
+ "serde",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1041,6 +1127,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
@@ -1087,6 +1179,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags 2.9.1",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1213,6 +1319,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.12",
+ "time",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1272,7 +1390,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -1287,12 +1414,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+
+[[package]]
+name = "time-macros"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -1502,6 +1671,12 @@ name = "unicode-width"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "user"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -15,3 +15,5 @@ pam = "0.7.0"
 users = "0.11.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+jsonwebtoken = "9.2"
+glob = "0.3"

--- a/backend/src/api/agents.rs
+++ b/backend/src/api/agents.rs
@@ -1,0 +1,45 @@
+use axum::{routing::get, Json, Router};
+use glob::glob;
+use serde::{Deserialize, Serialize};
+use std::fs;
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct Agent {
+    pub id: String,
+    pub hostname: String,
+    pub version: String,
+    pub cpu_load: [f64; 3],
+    pub mem_used_mb: u64,
+    pub disk_used_mb: u64,
+    pub net_rx_kb: u64,
+    pub alert: bool,
+    pub last_seen: String,
+}
+
+pub fn routes() -> Router {
+    Router::new().route("/", get(get_all_agents_handler))
+}
+
+async fn get_all_agents_handler() -> Json<Vec<Agent>> {
+    let agents = load_all_agents_from_run().await;
+    Json(agents)
+}
+
+async fn load_all_agents_from_run() -> Vec<Agent> {
+    let mut agents = vec![];
+
+    for entry in glob("/run/eclipta/*.json").expect("Failed to read glob pattern") {
+        if let Ok(path) = entry {
+            if path.is_file() {
+                if let Ok(contents) = fs::read_to_string(&path) {
+                    match serde_json::from_str::<Agent>(&contents) {
+                        Ok(agent) => agents.push(agent),
+                        Err(e) => eprintln!("Failed to parse {}: {}", path.display(), e),
+                    }
+                }
+            }
+        }
+    }
+
+    agents
+}

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -1,8 +1,10 @@
 pub mod auth;
-
+pub mod agents;
 use axum::Router;
+
 
 pub fn routes() -> Router {
     Router::new()
-        .nest("/auth", auth::routes()) 
+        .nest("/auth", auth::routes())
+        .nest("/agents", agents::routes())
 }

--- a/backend/src/services/jwt.rs
+++ b/backend/src/services/jwt.rs
@@ -1,0 +1,27 @@
+use jsonwebtoken::{encode, EncodingKey, Header};
+use std::time::{SystemTime, UNIX_EPOCH};
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Claims { // <- add `pub` here
+    pub sub: String,
+    pub is_admin: bool,
+    pub exp: usize,
+}
+
+pub fn generate_token(username: &str, is_admin: bool) -> Result<String, String> {
+    let expiration = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs() + 3600; // 1 hour
+
+    let claims = Claims {
+        sub: username.to_owned(),
+        is_admin,
+        exp: expiration as usize,
+    };
+
+    encode(&Header::default(), &claims, &EncodingKey::from_secret("mysecret".as_ref()))
+        .map_err(|e| e.to_string())
+}

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -1,12 +1,15 @@
+
 use pam::Authenticator;
 use std::process::Command;
 use users;
+pub mod jwt;
+
 
 pub fn pam_auth(username: &str, password: &str) -> Result<bool, String> {
     let mut auth = Authenticator::with_password("login").map_err(|e| e.to_string())?;
 
     let handler = auth.get_handler();
-    handler.set_credentials(username, password); // <- just call it, no check
+    handler.set_credentials(username, password);
 
     auth.authenticate().map_err(|e| e.to_string())?;
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,5 +1,5 @@
 #root {
-  padding: 2rem;
+  padding: 0;
 }
 
 .logo {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,15 +1,20 @@
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
+import { Routes, Route, Navigate } from 'react-router-dom'
+import { useAuth } from './contexts/AuthContext'
 import Login from './auth/Login'
+import Dashboard from './pages/dashboard'
 
 function App() {
+  const { isAuthenticated } = useAuth()
+
   return (
-    <Router>
-      <Routes>
-        <Route path="/auth" element={<Login />} />
-        {/* Add more routes as needed */}
-        <Route path="*" element={<div className="p-10  text-xl">404 Not Found</div>} />
-      </Routes>
-    </Router>
+    <Routes>
+      <Route path="/auth" element={<Login />} />
+      <Route
+        path="/dashboard"
+        element={isAuthenticated ? <Dashboard /> : <Navigate to="/auth" />}
+      />
+      <Route path="*" element={<Navigate to="/dashboard" />} />
+    </Routes>
   )
 }
 

--- a/frontend/src/auth/Login.tsx
+++ b/frontend/src/auth/Login.tsx
@@ -1,13 +1,17 @@
 import { useState } from 'react'
+import { useAuth } from '../contexts/AuthContext'
+import { useNavigate } from 'react-router-dom'
 
 function Login() {
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
-  const [message, setMessage] = useState('')
+  const [message, setMessage] = useState({})
+  const { setToken } = useAuth()
+  const navigate = useNavigate()
+
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault()
-
     try {
       const res = await fetch('http://localhost:3000/api/auth/login', {
         method: 'POST',
@@ -15,12 +19,24 @@ function Login() {
         body: JSON.stringify({ username, password }),
       })
 
-      const text = await res.text()
-      setMessage(text)
+      if (!res.ok) {
+        const errorText = await res.text()
+        setMessage('Login failed: ' + errorText)
+        return
+      }
+
+      const data = await res.json()
+      if (data.token) {
+        setToken(data.token)
+        navigate('/dashboard')
+      } else {
+        setMessage('Login failed: no token in response')
+      }
     } catch (err) {
       setMessage('Login error')
     }
   }
+
 
   return (
     <div className="min-h-screen bg-slate-50 flex items-center justify-center px-4">
@@ -60,12 +76,6 @@ function Login() {
             Sign In
           </button>
         </form>
-
-        {message && (
-          <div className="text-center text-sm text-gray-600 mt-2">
-            {message}
-          </div>
-        )}
       </div>
     </div>
   )

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,0 +1,85 @@
+import React, { useState } from 'react';
+import { motion, AnimatePresence, type Variants } from 'framer-motion';
+import { FiHome, FiServer, FiSettings, FiChevronLeft, FiChevronRight, FiLogOut, FiBox } from 'react-icons/fi';
+
+const Sidebar = () => {
+  const [isOpen, setIsOpen] = useState(true);
+
+  const toggleSidebar = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const sidebarVariants: Variants = {
+    open: { width: '250px', transition: { duration: 0.3, ease: "easeInOut" } },
+    closed: { width: '80px', transition: { duration: 0.3, ease: "easeInOut" } },
+  };
+
+  const itemVariants: Variants = {
+    open: { opacity: 1, x: 0, display: 'flex', transition: { duration: 0.3, ease: "easeInOut" } },
+    closed: { opacity: 0, x: -10, transitionEnd: { display: 'none' } },
+  };
+
+  const iconVariants = {
+    open: { marginRight: '1rem' },
+    closed: { marginRight: '0' },
+  };
+
+  return (
+    <motion.div
+      variants={sidebarVariants}
+      animate={isOpen ? 'open' : 'closed'}
+      className="bg-white text-gray-800 h-screen p-4 flex flex-col justify-between shadow-lg border-r border-gray-200"
+    >
+      <div>
+        <div className="flex items-center justify-between mb-8">
+          <AnimatePresence>
+            {isOpen && (
+              <motion.div
+                initial={{ opacity: 0, x: -20 }}
+                animate={{ opacity: 1, x: 0 }}
+                exit={{ opacity: 0, x: -20 }}
+                className="flex items-center"
+              >
+                <FiBox className="text-3xl text-indigo-600 mr-2" />
+                <h1 className="text-2xl font-bold">Eclipta</h1>
+              </motion.div>
+            )}
+          </AnimatePresence>
+          <button onClick={toggleSidebar} className="text-2xl p-1 rounded-full hover:bg-gray-200 transition-colors">
+            {isOpen ? <FiChevronLeft /> : <FiChevronRight />}
+          </button>
+        </div>
+        <ul>
+          {[
+            { icon: FiHome, text: 'Dashboard' },
+            { icon: FiServer, text: 'Servers' },
+            { icon: FiSettings, text: 'Settings' },
+          ].map((item, index) => (
+            <li key={index} className="mb-4">
+              <a href="#" className="flex items-center p-2 hover:bg-gray-100 rounded-lg transition-colors">
+                <motion.div variants={iconVariants} animate={isOpen ? 'open' : 'closed'}>
+                  <item.icon className="text-2xl" />
+                </motion.div>
+                <AnimatePresence>
+                  {isOpen && <motion.span variants={itemVariants} initial="closed" animate="open" exit="closed">{item.text}</motion.span>}
+                </AnimatePresence>
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div>
+        <a href="#" className="flex items-center p-2 hover:bg-gray-100 rounded-lg transition-colors">
+          <motion.div variants={iconVariants} animate={isOpen ? 'open' : 'closed'}>
+            <FiLogOut className="text-2xl" />
+          </motion.div>
+          <AnimatePresence>
+            {isOpen && <motion.span variants={itemVariants} initial="closed" animate="open" exit="closed">Logout</motion.span>}
+          </AnimatePresence>
+        </a>
+      </div>
+    </motion.div>
+  );
+};
+
+export default Sidebar;

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,0 +1,41 @@
+import { createContext, useContext, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+type AuthContextType = {
+  token: string | null
+  isAuthenticated: boolean
+  setToken: (token: string | null) => void
+  logout: () => void
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined)
+
+export function AuthProvider({ children }: any) {
+  const [token, setTokenState] = useState<string | null>(null)
+  const navigate = useNavigate()
+
+  const setToken = (newToken: string | null) => {
+    setTokenState(newToken)
+    if (!newToken) navigate('/auth') // auto-logout redirect
+  }
+
+  const logout = () => {
+    setToken(null)
+  }
+
+  const isAuthenticated = token !== null
+
+  return (
+    <AuthContext.Provider value={{ token, isAuthenticated, setToken, logout }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext)
+  if (!context) {
+    throw new Error('useAuth must be used within AuthProvider')
+  }
+  return context
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,16 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
+import { AuthProvider } from './contexts/AuthContext'
+import App from './App'
 import './index.css'
-import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
-  </StrictMode>,
+    <BrowserRouter>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </BrowserRouter>
+  </StrictMode>
 )

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -1,0 +1,15 @@
+import Sidebar from '../components/Sidebar';
+
+const Dashboard = () => {
+    return(
+        <div className="flex bg-gray-50 min-h-screen">
+            <Sidebar />
+            <main className="flex-1 p-8">
+                <h1 className="text-3xl font-bold text-gray-800">Dashboard</h1>
+                <p className="text-gray-600 mt-2">Welcome to your Eclipta dashboard.</p>
+            </main>
+        </div>
+    )
+}
+
+export default Dashboard;


### PR DESCRIPTION
- Added Axum-based HTTP server with a /agents route
- Dynamically reads all /run/eclipta/*.json files
- Parses agent data using Serde and returns as JSON list
- Enables real-time visibility into active agents via REST API
- Added dependencies: axum, tokio, serde, glob, serde_json